### PR TITLE
unnecessary cp commands

### DIFF
--- a/azure-pipelines-azureagent/files/start.sh
+++ b/azure-pipelines-azureagent/files/start.sh
@@ -21,9 +21,6 @@ trap 'exit 143' TERM
 cp /mnt/config/.agent ./
 cp /mnt/config/.credentials ./
 cp /mnt/config/.credentials_rsaparams ./
-cp /mnt/config/.env ./
-cp /mnt/config/.path ./
-cp /mnt/config/license.html ./
 
 chmod +x ./run.sh
 


### PR DESCRIPTION
Minor changes of the start.sh script (some cp commands are useless because the files they copy are actually created by the client software)