### PR TITLE
upgrade of ubuntu to release 24.04 for az agent container

### DIFF
--- a/azure-pipelines-azureagent/Dockerfile
+++ b/azure-pipelines-azureagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommend
     jq \
     lsb-release \
     software-properties-common \
-    libicu70
+    libicu74
 
 # Can be 'linux-x64', 'linux-arm64', 'linux-arm', 'rhel.6-x64'.
 ARG az_ag_release


### PR DESCRIPTION
libicu70 replaced by libicu74 for compatibiliy